### PR TITLE
fixed email address for subscription to google email list

### DIFF
--- a/_includes/landingpage/block_2.html
+++ b/_includes/landingpage/block_2.html
@@ -4,5 +4,5 @@
 </section>
 <section>
   <h3>Email list</h3>
-  <p>You can join our email list to send and receive information about events all around parallel-in-time integration: Just send an email to <em>parallelintime-subscribe[AT]googlegroups.com</em> and wait for your request to be accepted.</p>
+  <p>You can join our email list to send and receive information about events all around parallel-in-time integration: Just send an email to <em>parallelintime+subscribe[AT]googlegroups.com</em> and wait for your request to be accepted.</p>
 </section>


### PR DESCRIPTION
Should be parallelintime+subscribe@googlegroups.com and not with a dash.