### PR TITLE
Add sc committee navbar

### DIFF
--- a/_includes/navs/events.html
+++ b/_includes/navs/events.html
@@ -14,6 +14,9 @@
       <li {% if page.subnavbar == 'Bylaws' %}class="active"{% endif %}>
         <a href="{{ root_url }}/events/bylaws.html">Bylaws</a>
       </li>
+      <li {% if page.subnavbar == 'Scientific Committee' %}class="active"{% endif %}>
+        <a href="{{ root_url }}/events/scientific_committee.html">Scientific committee</a>
+      </li>      
     </ul>
   </li>
 {% else %}

--- a/events/scientific_committee.markdown
+++ b/events/scientific_committee.markdown
@@ -9,4 +9,14 @@ sharing: false
 footer: true
 ---
 
-Text.
+Following the [bylaws](/events/bylaws.html) of the PINT workshop series, in the aftermath of the [4th workshop on parallel-in-time integration](/events/past/2015/4th-workshop-on-parallel-in-time-integration.html) in 2015 in Dresden, seven colleagues have been elected as members of the scientific committee:
+
+ - Martin J. Gander, University of Geneva, Switzerland
+ - Stefan Güttel, University of Manchester, UK
+ - Ron Haynes, Memorial University of Newfoundland, Canada
+ - Rolf Krause, University of Lugano, Switzerland,
+ - Daniel Ruprecht, University of Lugano, Switzerland (soon: University of Leeds, UK)
+ - Jacob Schroder, Lawrence Livermore National Laboratory, USA
+ - Robert Speck, Jülich Supercomputing Centre, Germany
+
+After the workshop in 2017, three members will resign and a new vote will be held for these three positions.

--- a/events/scientific_committee.markdown
+++ b/events/scientific_committee.markdown
@@ -1,0 +1,12 @@
+---
+layout: page
+title: "Scientific committee of the PINT workshop series"
+created: 2015-07-06 14:00:00 +0200
+navbar: Events
+subnavbar: Scientific Committee
+comments: false
+sharing: false
+footer: true
+---
+
+Text.


### PR DESCRIPTION
- adds a new navbar under events / workshops called 'Scientific committee'
- adds an entry to  _includes/navs/events.html so this navbar shows up
- provides list of colleagues elected for the scientific committee

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/parallel-in-time/parallel-in-time.github.io/47)
<!-- Reviewable:end -->
