### PR TITLE
the URL filter from jekyll-scholar 4.3.6+ doesn't work

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org/'
 
 gem 'octopress'
 gem 'stringex'
-gem 'jekyll-scholar'
+gem 'jekyll-scholar', '<=4.3.5'
 
 
 group :deployment do


### PR DESCRIPTION
I don't know why, but my custom URL filter works way better than the
upstream one by jekyll-scholar itself.
Thus limiting the version of jekyll-scholar to 4.3.5.

This should fix #44.

@danielru could you test this, please? After checkout run `bundle update` first.