### PR TITLE
beautify contributor list

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -5,4 +5,6 @@ Matthew Emmett <memmett@gmail.com> <mwemmett@lbl.gov>
 Daniel Ruprecht <daniel.ruprecht@usi.ch> danielru <daniel@comp.usilu.net>
 Daniel Ruprecht <daniel.ruprecht@usi.ch> Daniel <daniel@D-Laptop.local>
 Daniel Ruprecht <daniel.ruprecht@usi.ch> Daniel <daniel@comp.usilu.net>
+Daniel Ruprecht <daniel.ruprecht@usi.ch> Daniel Ruprecht <danielru@users.noreply.github.com>
 Selman Terzi <sterzi@hotmail.de>
+Stephanie Friedhoff <stephanie.friedhoff@alumni.tufts.edu>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,0 +1,9 @@
+Matthew Emmett <memmett@gmail.com>
+Stephanie Friedhoff <stephanie.friedhoff@alumni.tufts.edu>
+Torbjörn Klatt <t.klatt@fz-juelich.de>
+Gijs Kooij <gijskooij@gmail.com>
+Ben Ong <ongbw@msu.edu>
+Daniel Ruprecht <daniel.ruprecht@usi.ch>
+Martin Schreiber <schreiberx@gmail.com>
+Jacob Schroder <schroder2@llnl.gov>
+Robert Speck <r.speck@fz-juelich.de>

--- a/about/imprint.md
+++ b/about/imprint.md
@@ -10,7 +10,7 @@ footer: true
 
 Hosted by [Daniel Ruprecht](https://github.com/danielru).
 Design and implementation by [Torbjörn Klatt](https://github.com/torbjoernk).
-Contributions by [various](https://github.com/Parallel-in-Time/parallel-in-time.github.io/graphs/contributors).
+Contributions by [various](https://github.com/Parallel-in-Time/parallel-in-time.github.io/blob/source/CONTRIBUTORS).
 
 Based on the following tools and libraries:
 


### PR DESCRIPTION
The contributors graph is messed up due to building it with Jenkins. Thus I created a `CONTRIBUTORS` file based on `git log --format='%aN <%aE>' | sort -u` of the source branch using the `.mailmap` file and subsequent manual alphabetical sorting of the surnames.

We might want to omit the email addresses in the new file.