### PR TITLE
add wayback urls & moved toulouse workshop

### DIFF
--- a/_events_past/2011-06-03-1st-pint-workshop.md
+++ b/_events_past/2011-06-03-1st-pint-workshop.md
@@ -4,12 +4,13 @@ title: "1st Workshop on Parallel-in-Time Integration"
 date: 2014-06-16 00:00:00 +0000
 event_url: https://www.ics.usi.ch/index.php/about/event/details/19-parallel-in-time-integration-schemes
 event_short_url: icsweb.inf.unisi.ch
+wayback_url: https://web.archive.org/web/20150919013709/http://icsweb.inf.unisi.ch/cms/index.php/events/details/19-parallel-in-time-integration-schemes.html
 event_location: Lugano, Switzerland
 event_start: 2011-06-03 00:00
 event_end: 2011-06-03 00:00
 navbar: Events
 subnavbar: Past
-permalink: /events/past/2011/1st-workshop-on-parallel-in-time-integration.html
+permalink: /events/2011/1st-workshop-on-parallel-in-time-integration.html
 organizers:
     - name: Daniel Ruprecht
       email: daniel.ruprecht@usi.ch

--- a/_events_past/2013-06-17-2nd-pint-workshop.md
+++ b/_events_past/2013-06-17-2nd-pint-workshop.md
@@ -7,9 +7,10 @@ event_start: 2013-06-17 00:00
 event_end: 2013-06-19 00:00
 event_url: http://www.cl.eps.manchester.ac.uk/medialand/maths/archived-events/workshops/www.mims.manchester.ac.uk/events/workshops/spacetime/
 event_short_url: cl.eps.manchester.ac.uk
+wayback_url: https://web.archive.org/web/20160121070129/http://www.cl.eps.manchester.ac.uk/medialand/maths/archived-events/workshops/www.mims.manchester.ac.uk/events/workshops/spacetime/
 navbar: Events
 subnavbar: Past
-permalink: /events/past/2013/2nd-workshop-on-parallel-in-time-integration.html
+permalink: /events/2013/2nd-workshop-on-parallel-in-time-integration.html
 organizers:
     - name: Stefan Güttel
       homepage: http://www.maths.manchester.ac.uk/~stefan/

--- a/_events_past/2014-05-20-3rd-pint-workshop.md
+++ b/_events_past/2014-05-20-3rd-pint-workshop.md
@@ -6,6 +6,7 @@ navbar: Events
 subnavbar: Past
 event_url: http://www.fz-juelich.de/ias/jsc/pintws2014
 event_short_url: fz-juelich.de
+wayback_url: https://web.archive.org/web/20160121070300/http://www.fz-juelich.de/ias/jsc/EN/Expertise/Workshops/Conferences/PinTWorkshop-2014/_node.html
 event_location: Jülich, Germany
 event_start: 2014-05-26 00:00
 event_end: 2014-05-28 00:00
@@ -29,7 +30,7 @@ invited:
     homepage: http://neumann.math.tufts.edu/
   - name: Cornelius Oosterlee
     homepage: http://ta.twi.tudelft.nl/mf/users/oosterle/
-permalink: /events/past/2014/3rd-workshop-on-parallel-in-time-integration.html
+permalink: /events/2014/3rd-workshop-on-parallel-in-time-integration.html
 logo: logo_jsc.png
 ---
 

--- a/_events_past/2015-4th-pint-workshop.md
+++ b/_events_past/2015-4th-pint-workshop.md
@@ -6,11 +6,12 @@ updated: 2015-06-05 05:30:00 +0200
 event_location: Dresden, Germany
 event_url: http://www.math.tu-dresden.de/~naumann/pint2015/
 event_short_url: math.tu-dresden.de
+wayback_url: https://web.archive.org/web/20150110103402/http://www.math.tu-dresden.de/~naumann/pint2015/
 event_start: 2015-05-27 00:00
 event_end: 2015-05-29 00:00
 navbar: Events
 subnavbar: Past
-permalink: /events/past/2015/4th-workshop-on-parallel-in-time-integration.html
+permalink: /events/2015/4th-workshop-on-parallel-in-time-integration.html
 organizers:
     - name: Jörg Wensch
       homepage: http://tu-dresden.de/die_tu_dresden/fakultaeten/fakultaet_mathematik_und_naturwissenschaften/fachrichtung_mathematik/institute/wir/staff/Professoren/wensch_html

--- a/_events_past/2016-01-11-cimi_semester.md
+++ b/_events_past/2016-01-11-cimi_semester.md
@@ -5,11 +5,12 @@ date: 2015-03-28 10:00:00 +0000
 event_location: University Paul Sabatier, Toulouse, France
 event_url: http://inpact.inp-toulouse.fr/CIMI_Semester/wksp_parallel.html
 event_short_url: inpact.inp-toulouse.fr
+wayback_url: https://web.archive.org/web/20160119063349/http://inpact.inp-toulouse.fr/CIMI_Semester/wksp_parallel.html
 event_start: 2016-01-11 00:00
 event_end: 2016-01-12 00:00
 navbar: Events
-subnavbar: Upcoming
-permalink: /events/upcoming/2016/cimi_semester.html
+subnavbar: Past
+permalink: /events/2016/cimi_semester.html
 organizers:
     - name: Xavier Vasseur
       email: vasseur@cerfacs.fr

--- a/_events_upcoming/2016-11-27-5h-pint-workshop.md
+++ b/_events_upcoming/2016-11-27-5h-pint-workshop.md
@@ -8,7 +8,7 @@ event_end: 2016-12-02 00:00
 event_url: http://www.birs.ca/events/2016/5-day-workshops/16w5030
 navbar: Events
 subnavbar: Upcoming
-permalink: /events/upcoming/2016/5th-workshop-on-parallel-in-time-integration.html
+permalink: /events/2016/5th-workshop-on-parallel-in-time-integration.html
 organizers:
   - name: Matt Emmett
     homepage: https://ccse.lbl.gov/people/emmett/

--- a/_includes/asides/event_meta.html
+++ b/_includes/asides/event_meta.html
@@ -14,7 +14,15 @@
       <div class="row">
         <label class="col-md-4 control-label">Homepage</label>
         <div class="col-md-8">
-          <a href="{{ page.event_url }}">{% if page.event_short_url %}{{ page.event_short_url }}{% else %}{{ page.event_url | trim_url }}{% endif %}</a>
+          <a href="{{ page.event_url }}" target="_blank">{% if page.event_short_url %}{{ page.event_short_url }}{% else %}{{ page.event_url | trim_url }}{% endif %}</a>
+          {% if page.wayback_url %}
+            <span class="pull-right">
+              <a href="{{ page.wayback_url }}" target="_blank"
+                 title="Event web site in Archive.org Wayback machine">
+                <i class="fa fa-history fa-fw"></i>
+              </a>
+            </span>
+          {% endif %}
         </div>
       </div>
     {% endif %}


### PR DESCRIPTION
It is now possible to add a link to the wayback machine for events.
Simply add a YAML variable `wayback_url` to the event pointing
to the URL in the Archive.org's wayback machine.