### PR TITLE
fix links in references again

### DIFF
--- a/_plugins/scholar.rb
+++ b/_plugins/scholar.rb
@@ -10,10 +10,14 @@ end
 
 require 'uri'
 
-module MarkdownFilter
-  class Markdown < BibTeX::Filter
-    def apply(value)
-      value.to_s.gsub(URI.regexp(['http','https','ftp'])) { |c| "<a href=\"#{$&}\">#{$&}</a>" }
+module Jekyll
+  class Scholar
+    class Markdown < BibTeX::Filter
+      def apply(value)
+        value.to_s.gsub(URI.regexp(['http','https','ftp'])) do |c|
+          "<a href=\"#{$&}\" target=\"_blank\">#{$&}</a>"
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Somehow the Markdown links generated by the Jekyll/scholar plugin are
not consumed by the Markdown converter.
We fix this by monkey patching the Jekyll/scholar filter itself.

Again fixes #44.