### PR TITLE
update gems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,7 @@ build/
 
 # for a library or gem, you might want to ignore these files since the code is
 # intended to run in multiple environments; otherwise, check them in:
-Gemfile.lock
+# Gemfile.lock
 # .ruby-version
 # .ruby-gemset
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.4.0)
-    autoprefixer-rails (6.3.0)
+    autoprefixer-rails (6.3.1)
       execjs
       json
     bibtex-ruby (4.1.2)
@@ -26,7 +26,7 @@ GEM
     fastimage (1.8.1)
       addressable (~> 2.3, >= 2.3.5)
     ffi (1.9.10)
-    jekyll (3.0.1)
+    jekyll (3.1.1)
       colorator (~> 0.1)
       jekyll-sass-converter (~> 1.0)
       jekyll-watch (~> 1.1)
@@ -45,13 +45,13 @@ GEM
     jekyll-paginate (1.1.0)
     jekyll-sass-converter (1.4.0)
       sass (~> 3.4)
-    jekyll-scholar (5.4.1)
+    jekyll-scholar (5.6.0)
       bibtex-ruby (~> 4.0, >= 4.0.13)
       citeproc-ruby (~> 1.0)
       csl-styles (~> 1.0)
       jekyll (~> 3.0)
-    jekyll-sitemap (0.9.0)
-    jekyll-watch (1.3.0)
+    jekyll-sitemap (0.10.0)
+    jekyll-watch (1.3.1)
       listen (~> 3.0)
     jgd (1.7.1)
       jekyll (>= 1.5.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,108 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.4.0)
+    autoprefixer-rails (6.3.0)
+      execjs
+      json
+    bibtex-ruby (4.1.2)
+      latex-decode (~> 0.0)
+    citeproc (1.0.2)
+      namae (~> 0.8)
+    citeproc-ruby (1.1.0)
+      citeproc (>= 1.0.2, < 2.0)
+      csl (~> 1.4)
+    coffee-script (2.4.1)
+      coffee-script-source
+      execjs
+    coffee-script-source (1.10.0)
+    colorator (0.1)
+    concurrent-ruby (1.0.0)
+    csl (1.4.3)
+      namae (~> 0.7)
+    csl-styles (1.0.1.6)
+      csl (~> 1.0)
+    execjs (2.6.0)
+    fastimage (1.8.1)
+      addressable (~> 2.3, >= 2.3.5)
+    ffi (1.9.10)
+    jekyll (3.0.1)
+      colorator (~> 0.1)
+      jekyll-sass-converter (~> 1.0)
+      jekyll-watch (~> 1.1)
+      kramdown (~> 1.3)
+      liquid (~> 3.0)
+      mercenary (~> 0.3.3)
+      rouge (~> 1.7)
+      safe_yaml (~> 1.0)
+    jekyll-assets (2.1.2)
+      fastimage (~> 1.8)
+      jekyll (~> 3.0)
+      sprockets (~> 3.3)
+      sprockets-helpers (~> 1.2)
+      tilt (~> 2.0)
+    jekyll-feed (0.4.0)
+    jekyll-paginate (1.1.0)
+    jekyll-sass-converter (1.4.0)
+      sass (~> 3.4)
+    jekyll-scholar (5.4.1)
+      bibtex-ruby (~> 4.0, >= 4.0.13)
+      citeproc-ruby (~> 1.0)
+      csl-styles (~> 1.0)
+      jekyll (~> 3.0)
+    jekyll-sitemap (0.9.0)
+    jekyll-watch (1.3.0)
+      listen (~> 3.0)
+    jgd (1.7.1)
+      jekyll (>= 1.5.1)
+      trollop (= 2.1.2)
+    json (1.8.3)
+    kramdown (1.9.0)
+    latex-decode (0.2.2)
+      unicode (~> 0.4)
+    liquid (3.0.6)
+    listen (3.0.5)
+      rb-fsevent (>= 0.9.3)
+      rb-inotify (>= 0.9)
+    mercenary (0.3.5)
+    mini_magick (4.3.6)
+    namae (0.10.1)
+    rack (1.6.4)
+    rb-fsevent (0.9.7)
+    rb-inotify (0.9.5)
+      ffi (>= 0.5.0)
+    rouge (1.10.1)
+    safe_yaml (1.0.4)
+    sass (3.4.21)
+    sprockets (3.5.2)
+      concurrent-ruby (~> 1.0)
+      rack (> 1, < 3)
+    sprockets-helpers (1.2.1)
+      sprockets (>= 2.2)
+    tilt (2.0.2)
+    trollop (2.1.2)
+    uglifier (2.7.2)
+      execjs (>= 0.3.0)
+      json (>= 1.8.0)
+    unicode (0.4.4.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  autoprefixer-rails
+  coffee-script
+  jekyll (>= 3.0)
+  jekyll-assets
+  jekyll-feed
+  jekyll-paginate
+  jekyll-scholar
+  jekyll-sitemap
+  jekyll-watch
+  jgd
+  mini_magick
+  sass
+  uglifier
+
+BUNDLED WITH
+   1.11.2


### PR DESCRIPTION
The `Gemfile.lock` file is now under version control. This way we can ensure a specific set of gems for everybody as long as nobody runs `bundler update` but only `bundler install --clean`.

So, whenever you detect a change in `Gemfile.lock` on the source branch and you pull in these changes to your local clone, run `bundler update --clean` to update your gemset and remove all unused gems.