### PR TITLE
Sub-pages for events (with major change)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -57,8 +57,10 @@ assets:
 collections:
   events_upcoming:
     output: true
+    permalink: /events/:title/
   events_past:
     output: true
+    permalink: /events/:title/
   groups:
     output: true
   projects:

--- a/_events_past/2011-06-03-1st-pint-workshop.md
+++ b/_events_past/2011-06-03-1st-pint-workshop.md
@@ -10,7 +10,7 @@ event_start: 2011-06-03 00:00
 event_end: 2011-06-03 00:00
 navbar: Events
 subnavbar: Past
-permalink: /events/2011/1st-workshop-on-parallel-in-time-integration.html
+permalink:
 organizers:
     - name: Daniel Ruprecht
       email: daniel.ruprecht@usi.ch

--- a/_events_past/2011-06-03-1st-pint-workshop.md
+++ b/_events_past/2011-06-03-1st-pint-workshop.md
@@ -10,16 +10,17 @@ event_start: 2011-06-03 00:00
 event_end: 2011-06-03 00:00
 navbar: Events
 subnavbar: Past
-permalink:
 organizers:
-    - name: Daniel Ruprecht
-      email: daniel.ruprecht@usi.ch
-    - name: Rolf Krause
+  - name: Daniel Ruprecht
+    email: daniel.ruprecht@usi.ch
+  - name: Rolf Krause
 invited:
-    - name: Martin Gander
-    - name: Julien Cortial
-    - name: Michael Minion
-    - name: Stefan Güttel
+  - name: Martin Gander
+  - name: Julien Cortial
+  - name: Michael Minion
+  - name: Stefan Güttel
+permalink:
+page_type: event_page
 ---
 
 Supported by the Swiss platform for *High Performance and High Productivity Computing* [HP2C](http://www.hp2c.ch/index.php?id=topicforums&tx_communities_pi1[eventid]=9&no_cache=1).

--- a/_events_past/2013-06-17-2nd-pint-workshop.md
+++ b/_events_past/2013-06-17-2nd-pint-workshop.md
@@ -10,15 +10,16 @@ event_short_url: cl.eps.manchester.ac.uk
 wayback_url: https://web.archive.org/web/20160121070129/http://www.cl.eps.manchester.ac.uk/medialand/maths/archived-events/workshops/www.mims.manchester.ac.uk/events/workshops/spacetime/
 navbar: Events
 subnavbar: Past
-permalink:
 organizers:
-    - name: Stefan Güttel
-      homepage: http://www.maths.manchester.ac.uk/~stefan/
+  - name: Stefan Güttel
+    homepage: http://www.maths.manchester.ac.uk/~stefan/
 invited:
-    - name: Martin Gander
-    - name: Yvon Maday
-    - name: Michael Minion
-    - name: Benjamin Ong
+  - name: Martin Gander
+  - name: Yvon Maday
+  - name: Michael Minion
+  - name: Benjamin Ong
+permalink:
+page_type: event_page
 ---
 
 A book of abstracts can be found [here](http://www.cl.eps.manchester.ac.uk/medialand/maths/archived-events/workshops/www.mims.manchester.ac.uk/events/workshops/spacetime/abstracts/booklet.pdf).

--- a/_events_past/2013-06-17-2nd-pint-workshop.md
+++ b/_events_past/2013-06-17-2nd-pint-workshop.md
@@ -10,7 +10,7 @@ event_short_url: cl.eps.manchester.ac.uk
 wayback_url: https://web.archive.org/web/20160121070129/http://www.cl.eps.manchester.ac.uk/medialand/maths/archived-events/workshops/www.mims.manchester.ac.uk/events/workshops/spacetime/
 navbar: Events
 subnavbar: Past
-permalink: /events/2013/2nd-workshop-on-parallel-in-time-integration.html
+permalink:
 organizers:
     - name: Stefan Güttel
       homepage: http://www.maths.manchester.ac.uk/~stefan/

--- a/_events_past/2014-05-20-3rd-pint-workshop.md
+++ b/_events_past/2014-05-20-3rd-pint-workshop.md
@@ -30,7 +30,7 @@ invited:
     homepage: http://neumann.math.tufts.edu/
   - name: Cornelius Oosterlee
     homepage: http://ta.twi.tudelft.nl/mf/users/oosterle/
-permalink: /events/2014/3rd-workshop-on-parallel-in-time-integration.html
+permalink:
 logo: logo_jsc.png
 ---
 

--- a/_events_past/2014-05-20-3rd-pint-workshop.md
+++ b/_events_past/2014-05-20-3rd-pint-workshop.md
@@ -30,8 +30,9 @@ invited:
     homepage: http://neumann.math.tufts.edu/
   - name: Cornelius Oosterlee
     homepage: http://ta.twi.tudelft.nl/mf/users/oosterle/
-permalink:
 logo: logo_jsc.png
+permalink:
+page_type: event_page
 ---
 
 Partially supported by the DFG Priority Programme 1648 *Software for Exascale Computing* [SPPEXA](http://www.sppexa.de/sppexa-activities/eventsworkshops.html).

--- a/_events_past/2015-05-27-4th-pint-workshop.md
+++ b/_events_past/2015-05-27-4th-pint-workshop.md
@@ -11,7 +11,7 @@ event_start: 2015-05-27 00:00
 event_end: 2015-05-29 00:00
 navbar: Events
 subnavbar: Past
-permalink: /events/2015/4th-workshop-on-parallel-in-time-integration.html
+permalink:
 organizers:
     - name: Jörg Wensch
       homepage: http://tu-dresden.de/die_tu_dresden/fakultaeten/fakultaet_mathematik_und_naturwissenschaften/fachrichtung_mathematik/institute/wir/staff/Professoren/wensch_html

--- a/_events_past/2015-05-27-4th-pint-workshop.md
+++ b/_events_past/2015-05-27-4th-pint-workshop.md
@@ -11,29 +11,30 @@ event_start: 2015-05-27 00:00
 event_end: 2015-05-29 00:00
 navbar: Events
 subnavbar: Past
-permalink:
 organizers:
-    - name: Jörg Wensch
-      homepage: http://tu-dresden.de/die_tu_dresden/fakultaeten/fakultaet_mathematik_und_naturwissenschaften/fachrichtung_mathematik/institute/wir/staff/Professoren/wensch_html
-    - name: Oswald Knoth
-      homepage: http://www.tropos.de/en/institute/about-us/employees/
-    - name: Robert Speck
-      homepage: http://www.fz-juelich.de/SharedDocs/Personen/IAS/JSC/EN/staff/speck_r.html
-      email: r.speckt@fz-juelich.de
-    - name: Daniel Ruprecht
-      homepage: http://icsweb.inf.unisi.ch/cms/index.php/people/29-daniel-ruprecht.html
-      email: daniel.ruprecht@usi.ch
+  - name: Jörg Wensch
+    homepage: http://tu-dresden.de/die_tu_dresden/fakultaeten/fakultaet_mathematik_und_naturwissenschaften/fachrichtung_mathematik/institute/wir/staff/Professoren/wensch_html
+  - name: Oswald Knoth
+    homepage: http://www.tropos.de/en/institute/about-us/employees/
+  - name: Robert Speck
+    homepage: http://www.fz-juelich.de/SharedDocs/Personen/IAS/JSC/EN/staff/speck_r.html
+    email: r.speckt@fz-juelich.de
+  - name: Daniel Ruprecht
+    homepage: http://icsweb.inf.unisi.ch/cms/index.php/people/29-daniel-ruprecht.html
+    email: daniel.ruprecht@usi.ch
 invited:
-    - name: Martin Gander
-      homepage: http://www.unige.ch/~gander/
-    - name: Hilary Weller
-      homepage: http://www.met.reading.ac.uk/~sws02hs/
-    - name: Michael Minion
-      homepage: https://profiles.stanford.edu/michael-minion
-    - name: Martin Arnold
-      homepage: http://sim.mathematik.uni-halle.de/~arnold/
-    - name: Beth Wingate
-      homepage: http://emps.exeter.ac.uk/mathematics/staff/bw290
+  - name: Martin Gander
+    homepage: http://www.unige.ch/~gander/
+  - name: Hilary Weller
+    homepage: http://www.met.reading.ac.uk/~sws02hs/
+  - name: Michael Minion
+    homepage: https://profiles.stanford.edu/michael-minion
+  - name: Martin Arnold
+    homepage: http://sim.mathematik.uni-halle.de/~arnold/
+  - name: Beth Wingate
+    homepage: http://emps.exeter.ac.uk/mathematics/staff/bw290
+permalink:
+page_type: event_page
 ---
 
 The next workshop on parallel-in-time integration, taking place in 2015 at TU Dresden.

--- a/_events_past/2016-01-11-cimi_semester.md
+++ b/_events_past/2016-01-11-cimi_semester.md
@@ -10,7 +10,7 @@ event_start: 2016-01-11 00:00
 event_end: 2016-01-12 00:00
 navbar: Events
 subnavbar: Past
-permalink: /events/2016/cimi_semester.html
+permalink:
 organizers:
     - name: Xavier Vasseur
       email: vasseur@cerfacs.fr

--- a/_events_past/2016-01-11-cimi_semester.md
+++ b/_events_past/2016-01-11-cimi_semester.md
@@ -10,19 +10,20 @@ event_start: 2016-01-11 00:00
 event_end: 2016-01-12 00:00
 navbar: Events
 subnavbar: Past
-permalink:
 organizers:
-    - name: Xavier Vasseur
-      email: vasseur@cerfacs.fr
-    - name: Serge Gratton
-      email: serge.gratton@enseeiht.fr
+  - name: Xavier Vasseur
+    email: vasseur@cerfacs.fr
+  - name: Serge Gratton
+    email: serge.gratton@enseeiht.fr
 invited:
-    - name: Matthew Emmett
-      homepage:
-    - name: Martin Gander
-      homepage: http://www.unige.ch/~gander/
-    - name: Robert Speck
-      homepage: http://www.fz-juelich.de/SharedDocs/Personen/IAS/JSC/EN/staff/speck_r.html
+  - name: Matthew Emmett
+    homepage:
+  - name: Martin Gander
+    homepage: http://www.unige.ch/~gander/
+  - name: Robert Speck
+    homepage: http://www.fz-juelich.de/SharedDocs/Personen/IAS/JSC/EN/staff/speck_r.html
+permalink:
+page_type: event_page
 ---
 
 In this workshop, we want to address the challenge of time-dependent

--- a/_events_upcoming/2016-11-27-5h-pint-workshop.md
+++ b/_events_upcoming/2016-11-27-5h-pint-workshop.md
@@ -8,7 +8,6 @@ event_end: 2016-12-02 00:00
 event_url: http://www.birs.ca/events/2016/5-day-workshops/16w5030
 navbar: Events
 subnavbar: Upcoming
-permalink: /events/2016/5th-workshop-on-parallel-in-time-integration.html
 organizers:
   - name: Matt Emmett
     homepage: http://ccse.lbl.gov/people/emmett/
@@ -20,6 +19,7 @@ organizers:
     homepage: http://icsweb.inf.unisi.ch/cms/index.php/people/23-rolf-krause.html
   - name: Michael Minion
     homepage: https://ccse.lbl.gov/people/minion/
+permalink:
 ---
 
 The Fifth Workshop on Parallel-in-time Integration Workshop will be

--- a/_events_upcoming/2016-11-27-5th-pint-workshop.md
+++ b/_events_upcoming/2016-11-27-5th-pint-workshop.md
@@ -1,6 +1,6 @@
 ---
 layout: page_event
-title: Fifth Workshop on Parallel-in-Time Integration
+title: 5th Workshop on Parallel-in-Time Integration
 date: 2014-06-16 00:00:00 +0000
 event_location: Banff, Canada
 event_start: 2016-11-27 00:00
@@ -20,6 +20,7 @@ organizers:
   - name: Michael Minion
     homepage: https://ccse.lbl.gov/people/minion/
 permalink:
+page_type: event_page
 ---
 
 The Fifth Workshop on Parallel-in-time Integration Workshop will be

--- a/_events_upcoming/2016-11-27-5th-pint-workshop/details.md
+++ b/_events_upcoming/2016-11-27-5th-pint-workshop/details.md
@@ -1,10 +1,29 @@
 ---
-layout: default
-title: Fifth Workshop on Parallel-in-Time Integration
+layout: page_event
+title: 5th Workshop on Parallel-in-Time Integration
+subtitle: Details
+date: 2014-06-16 00:00:00 +0000
+updated: 2016-02-23
+event_location: Banff, Canada
+event_start: 2016-11-27 00:00
+event_end: 2016-12-02 00:00
+event_url: http://www.birs.ca/events/2016/5-day-workshops/16w5030
+navbar: Events
+subnavbar: Upcoming
+organizers:
+  - name: Matt Emmett
+    homepage: http://ccse.lbl.gov/people/emmett/
+  - name: Martin Gander
+    homepage: http://www.unige.ch/~gander/
+  - name: Ron Haynes
+    homepage: http://www.mun.ca/math/people/ppl-faculty/rhaynes.php
+  - name: Rolf Krause
+    homepage: http://icsweb.inf.unisi.ch/cms/index.php/people/23-rolf-krause.html
+  - name: Michael Minion
+    homepage: https://ccse.lbl.gov/people/minion/
+permalink: /events/5th-pint-workshop/details/
+page_type: event_subpage
 ---
-
-# Fifth Parallel-in-Time Integration Workshop
-
 The Fifth Workshop on Parallel-in-time Integration Workshop will be
 held at the [Banff International Research Station (BIRS)][BIRS] from
 November 27 to December 2, 2016.  BIRS is located on the campus of the
@@ -35,7 +54,7 @@ The workshop is organised by
 
 in conjunction with the [Parallel-in-Time Scientific Committee][PINTSC].
 
-## Participation
+### Participation
 
 BIRS workshops are by invitation only.  If you would like to attend
 the workshop, please contact [Matthew
@@ -56,14 +75,14 @@ can be submitted online through [the abstract submission
 form][ABSTRACTS] or by emailing them to [Matthew
 Emmett](mailto:memmett@gmail.com).
 
-## Proceedings
+### Proceedings
 
 Participants with accepted abstracts will be invited to publish their
 contributions, in the format of a short paper (maximum of 20 pages) in
 the proceedings of the workshop, which will be published as a special
 issue of **Computing and Visualization in Science** (Springer).
 
-## Scientific Overview
+### Scientific Overview
 
 The efficient use of modern high performance computing (HPC) systems
 has become one of the key challenges in computational science.  Top
@@ -84,15 +103,15 @@ transfer operators in space and time, and how other features of
 time-parallel methods can be exploited to further enhance their
 applicability to complex systems.
 
-## Objectives
+### Objectives
 
-### Showcase
+#### Showcase
 
 Recent advances in parallel-in-time integration, in terms of both
 theoretical aspects and practical advances, will be showcased by
 participants through a series of contributed talks.
 
-### Educate
+#### Educate
 
 Our intended participants include young researchers as well as domain
 experts in time-parallel, multigrid, and domain decomposition methods.
@@ -101,7 +120,7 @@ theoretical understanding of the techniques and approaches involved in
 these fields and give participants a chance to further explore
 opportunities for collaboration.
 
-### Progress
+#### Progress
 
 Parallel-in-time integration methods have recently moved from
 proof-of-concept to production applications through the development of
@@ -113,7 +132,7 @@ also have an opportunity to exchange best-practises, design
 principles, pitfalls etc.
 
 
-## Programme
+### Programme
 
 
 This 5-day workshop will consist of numerous talks, open discussion
@@ -123,7 +142,7 @@ A detailed schedule will eventually be posted on our [PinT@BIRS
 2016][PINT16BIRS] website.
 
 
-## Funding
+### Funding
 
 
 The organisers and scientific committee would like to thank

--- a/_includes/asides/event_subnav.html
+++ b/_includes/asides/event_subnav.html
@@ -1,0 +1,33 @@
+{% assign current_base_arr = page.url | replace:'/events/','' | split:'/' %}
+{% assign current_base = current_base_arr | first %}
+{% assign current_base_size = current_base | size %}
+
+{% capture event_index_url %}{% if current_base_size == 0 %}{{ page.url | strip }}{% else %}/events/{{ current_base | strip }}{% endif %}/{% endcapture %}
+
+<nav id="subnav" class="clearfix" role="navigation">
+  <ul class="nav nav-tabs">
+    <li role="presentation"{% if event_index_url == page.url %} class="active"{% endif %}>
+      <a href="{{ event_index_url }}">Event's Main Page</a>
+    </li>
+    {% sorted_for subpage in site.events_upcoming %}
+      {% unless subpage.page_type == 'event_page' %}
+        {% assign subpage_url_arr = subpage.url | split:'/' %}
+        {% if subpage_url_arr contains current_base %}
+          <li role="presentation"{% if subpage.url == page.url %} class="active"{% endif %}>
+            <a href="{{ subpage.url }}">{{ subpage.subtitle }}</a>
+          </li>
+        {% endif %}
+      {% endunless %}
+    {% endsorted_for %}
+    {% sorted_for subpage in site.events_past %}
+      {% unless subpage.page_type == 'event_page' %}
+        {% assign subpage_url_arr = subpage.url | split:'/' %}
+        {% if subpage_url_arr contains current_base %}
+          <li role="presentation"{% if subpage.url == page.url %} class="active"{% endif %}>
+            <a href="{{ subpage.url }}">{{ subpage.subtitle }}</a>
+          </li>
+        {% endif %}
+      {% endunless %}
+    {% endsorted_for %}
+  </ul>
+</nav>

--- a/_layouts/page_event.html
+++ b/_layouts/page_event.html
@@ -2,18 +2,21 @@
 layout: default
 ---
 <div class="post post-event">
-  <header class="post-header">
-    <h1>{{ page.title }}</h1>
-    {% if page.subtitle %}
-      <h2>{{ page.subtitle }}</h2>
-    {% endif %}
-  </header>
+  <div class="row">
+    <header class="col-sm-12 post-header">
+      <h1>{{ page.title }}</h1>
+    </header>
+  </div>
   <article class="post-content">
     <div class="row">
-      <div class="col-md-8 content">
+      <div class="col-lg-7 col-sm-12 content" id="main-content">
+        {% include asides/event_subnav.html %}
+        {% if page.subtitle %}
+          <h2>{{ page.subtitle }}</h2>
+        {% endif %}
         {{ content }}
       </div>
-      <aside class="col-md-4">
+      <aside class="col-lg-5 col-sm-12 collapse in" id="meta-aside">
         {% include asides/event_meta.html %}
       </aside>
     </div>

--- a/_plugins/sorted_for.rb
+++ b/_plugins/sorted_for.rb
@@ -1,0 +1,63 @@
+module Jekyll
+  module SortedForImpl
+    def render(context)
+      sorted_collection = collection_to_sort context
+      return if sorted_collection.empty?
+      sort_attr = @attributes['sort_by']
+      case_sensitive = @attributes['case_sensitive'] == 'true'
+      i = sorted_collection.first
+
+      if sort_attr != nil
+        if i.to_liquid[sort_attr].instance_of? String and not case_sensitive
+          sorted_collection.sort_by! { |i| i.to_liquid[sort_attr].downcase }
+        else
+          sorted_collection.sort_by! { |i| i.to_liquid[sort_attr] }
+        end
+      else
+        if i.instance_of? String and not case_sensitive
+          sorted_collection.sort_by! { |i| i.downcase }
+        else
+          sorted_collection.sort!
+        end
+      end
+
+      original_name = @collection_name
+      result = nil
+      context.stack do
+        sorted_collection_name = "#{@collection_name}_sorted".sub('.', '_')
+        context[sorted_collection_name] = sorted_collection
+        @collection_name = sorted_collection_name
+        result = super
+        @collection_name = original_name
+      end
+      result
+    end
+  end
+
+  class SortedForTag < Liquid::For
+    include SortedForImpl
+
+    def collection_to_sort(context)
+      return context[@collection_name].dup
+    end
+
+    def end_tag
+      'endsorted_for'
+    end
+  end
+
+  class SortedKeysForTag < Liquid::For
+    include SortedForImpl
+
+    def collection_to_sort(context)
+      return context[@collection_name].keys
+    end
+
+    def end_tag
+      'endsorted_keys_for'
+    end
+  end
+end
+
+Liquid::Template.register_tag('sorted_for', Jekyll::SortedForTag)
+Liquid::Template.register_tag('sorted_keys_for', Jekyll::SortedKeysForTag)

--- a/events/index.html
+++ b/events/index.html
@@ -13,17 +13,21 @@ footer: false
   <div class="col-md-6">
     <h2>Upcoming</h2>
     <ul class="list-group">
-      {% for event in site.events_upcoming %}
-        {% include event/overview_item.html %}
-      {% endfor %}
+      {% sorted_for event in site.events_upcoming sort_by:event_start %}
+        {% if event.page_type == 'event_page' %}
+          {% include event/overview_item.html %}
+        {% endif %}
+      {% endsorted_for %}
     </ul>
   </div>
   <div class="col-md-6">
     <h2>Past</h2>
     <ul class="list-group">
-      {% for event in site.events_past reversed %}
-        {% include event/overview_item.html %}
-      {% endfor %}
+      {% sorted_for event in site.events_past reversed sort_by:event_start %}
+        {% if event.page_type == 'event_page' %}
+          {% include event/overview_item.html %}
+        {% endif %}
+      {% endsorted_for %}
     </ul>
   </div>
 </div>

--- a/events/past/index.html
+++ b/events/past/index.html
@@ -10,7 +10,9 @@ footer: false
 ---
 
 <ul class="list-group">
-  {% for event in site.events_past reversed %}
-    {% include event/overview_item.html %}
-  {% endfor %}
+  {% sorted_for event in site.events_past reversed sort_by:event_start %}
+    {% if event.page_type == 'event_page' %}
+      {% include event/overview_item.html %}
+    {% endif %}
+  {% endsorted_for %}
 </ul>

--- a/events/upcoming/index.html
+++ b/events/upcoming/index.html
@@ -10,7 +10,9 @@ footer: false
 ---
 
 <ul class="list-group">
-  {% for event in site.events_upcoming %}
-    {% include event/overview_item.html %}
-  {% endfor %}
+  {% sorted_for event in site.events_upcoming sort_by:event_start %}
+    {% if event.page_type == 'event_page' %}
+      {% include event/overview_item.html %}
+    {% endif %}
+  {% endsorted_for %}
 </ul>


### PR DESCRIPTION
This introduces per-event sub-pages. This feature has recently been implemented and deployed on the new and shiny [JLESC website](https://jlesc.github.io). As both sites are sharing the same backend, I copied that feature over to here.

**Important Note**: This required a major change with current URLs for event pages. They are now of the pattern `/events/TITLE/` and not `/events/YEAR_OF_PUBLICATION/TITLE/`. The later has already been broken as most event pages' YAML front matter state a wrong date of publication (YAML field `date`).

In case everybody is happy with these sub-pages, I'm happy to enable them also for projects, methods and codes. As well, I can add that eye-pleasing collapsing of the meta aside.