### PR TITLE
Make event meta aside collapsible

### DIFF
--- a/_assets/css/main.scss
+++ b/_assets/css/main.scss
@@ -36,6 +36,34 @@ html {
       }
     }
 
+    aside {
+      #hide-meta-aside {
+        border: 0 !important;
+
+        i {
+          vertical-align: middle;
+        }
+      }
+    }
+
+    #subnav #show-meta-aside-wrapper {
+      @include pull-right();
+      text-align: right;
+
+      &:focus,
+      &:hover,
+      a {
+        border: 0 !important;
+        background: none;
+      }
+
+      a {
+        i {
+          vertical-align: middle;
+        }
+      }
+    }
+
     .event-meta {
       .label {
         margin: 0.25em;

--- a/_assets/js/custom.js
+++ b/_assets/js/custom.js
@@ -1,32 +1,42 @@
 //= require ./vendor/bootstrap-sprockets
 //= require ./vendor/jquery.githubRepoWidget
 
+var toggle_meta_aside = function(desired_state) {
+    var meta_aside = $('#meta-aside');
+
+    if (desired_state === 'show' && meta_aside.hasClass('invisible')) {
+        // make aside meta visible again
+        $('#show-meta-aside').addClass('invisible');
+        meta_aside.removeClass('invisible').addClass('in');
+        $('article div#main-content').addClass('col-lg-7').removeClass('col-lg-12');
+
+    } else if (desired_state === 'hide' && !meta_aside.hasClass('invisible')) {
+        // make aside meta invisible
+        $('#show-meta-aside').removeClass('invisible');
+        meta_aside.addClass('invisible').removeClass('in');
+        $('article div#main-content').removeClass('col-lg-7').addClass('col-lg-12');
+    }
+};
+
 $(document).ready(function() {
-    // from http://stackoverflow.com/a/20469901/588243
-    $.extend({
-        replaceTag: function (currentElem, newTagObj, keepProps) {
-            var $currentElem = $(currentElem);
-            var i, $newTag = $(newTagObj).clone();
-            if (keepProps) {
-                newTag = $newTag[0];
-                newTag.className = currentElem.className;
-                $.extend(newTag.classList, currentElem.classList);
-                $.extend(newTag.attributes, currentElem.attributes);
-            }
-            $currentElem.wrapAll($newTag);
-            $currentElem.contents().unwrap();
-            return this; // Suggested by ColeLawrence
-        }
+    // activate tooltips
+    $('[data-toggle="tooltip"]').tooltip();
+
+    $('#hide-meta-aside').click(function() {
+        toggle_meta_aside('hide')
     });
-    $.fn.extend({
-        replaceTag: function (newTagObj, keepProps) {
-            return this.each(function() {
-                jQuery.replaceTag(this, newTagObj, keepProps);
-            });
-        }
+
+    $('#show-meta-aside').click(function() {
+        toggle_meta_aside('show')
     });
 
     $('article.post-content[data-with-lead="true"]').find('.content > p:first').addClass('lead');
+
+    var event_article = $('.post-event article');
+    if (event_article.attr('data-page-type') === 'event_subpage') {
+        // we are on an event's sub-page
+        toggle_meta_aside('hide');
+    }
 
     //
     // Beautify Ref Lists

--- a/_includes/asides/event_meta.html
+++ b/_includes/asides/event_meta.html
@@ -1,6 +1,13 @@
 <section class="event-meta panel panel-default">
   <div class="panel-heading">
-    <h3 class="panel-title">Workshop Profile</h3>
+    <h3 class="panel-title">
+      Workshop Profile
+      <span class="pull-right">
+        <a id="hide-meta-aside" role="button" title="Hide Profile" data-toggle="tooltip">
+          <i class="fa fa-fw fa-minus"></i>
+        </a>
+      </span>
+    </h3>
   </div>
   <div class="panel-body">
     {% if page.logo %}

--- a/_includes/asides/event_subnav.html
+++ b/_includes/asides/event_subnav.html
@@ -9,7 +9,7 @@
     <li role="presentation"{% if event_index_url == page.url %} class="active"{% endif %}>
       <a href="{{ event_index_url }}">Event's Main Page</a>
     </li>
-    {% sorted_for subpage in site.events_upcoming %}
+    {% sorted_for subpage in site.events_upcoming sort_by:subtitle %}
       {% unless subpage.page_type == 'event_page' %}
         {% assign subpage_url_arr = subpage.url | split:'/' %}
         {% if subpage_url_arr contains current_base %}
@@ -19,7 +19,7 @@
         {% endif %}
       {% endunless %}
     {% endsorted_for %}
-    {% sorted_for subpage in site.events_past %}
+    {% sorted_for subpage in site.events_past sort_by:subtitle %}
       {% unless subpage.page_type == 'event_page' %}
         {% assign subpage_url_arr = subpage.url | split:'/' %}
         {% if subpage_url_arr contains current_base %}
@@ -29,5 +29,10 @@
         {% endif %}
       {% endunless %}
     {% endsorted_for %}
+    <li id="show-meta-aside-wrapper" role="presentation">
+      <a class="invisible" id="show-meta-aside" role="button" title="Show Profile" data-toggle="tooltip">
+        <i class="fa fa-fw fa-info"></i>
+      </a>
+    </li>
   </ul>
 </nav>

--- a/_layouts/page_event.html
+++ b/_layouts/page_event.html
@@ -7,16 +7,18 @@ layout: default
       <h1>{{ page.title }}</h1>
     </header>
   </div>
-  <article class="post-content" data-with-lead="{% if page.no_lead %}false{% else %}true{% endif %}">
+  <article class="post-content"
+           data-with-lead="{% if page.no_lead %}false{% else %}true{% endif %}"
+           data-page-type="{{ page.page_type }}">
     <div class="row">
-      <div class="{% if page.page_type == 'event_page' %}col-lg-7{% else %}col-lg-12{% endif %} col-sm-12 content" id="main-content">
+      <div class="col-lg-7 col-sm-12 content" id="main-content">
         {% include asides/event_subnav.html %}
         {% if page.subtitle %}
           <h2>{{ page.subtitle }}</h2>
         {% endif %}
         {{ content }}
       </div>
-      <aside class="col-lg-5 col-sm-12 collapse {% if page.page_type == 'event_page' %}in{% else %}invisible{% endif %}" id="meta-aside">
+      <aside class="col-lg-5 col-sm-12 collapse in" id="meta-aside">
         {% include asides/event_meta.html %}
       </aside>
     </div>


### PR DESCRIPTION
The aside box with an event's meta info is now collapsible with some
JavaScript. On event's sub-pages this box is collapsed by default but
can be expanded.