### PR TITLE
fixed several links in news entries

### DIFF
--- a/_posts/2014-08-04-new-workshop-announcement.md
+++ b/_posts/2014-08-04-new-workshop-announcement.md
@@ -14,4 +14,4 @@ The 4th Workshop on Parallel-in-Time Integration will take place in May 2015 in 
 After three workshops in Lugano (2011), Manchester (2013) and Juelich (2014), the workshop series on parallel-in-time 
 integration continues in 2015 with a workshop at TU Dresden from May 27 to May 29.
 For more information, check out the homepage at [TU Dresden](http://www.math.tu-dresden.de/~naumann/pint2015) and the
-entry at [parallelintime.org](/events/past/2015/4th-workshop-on-parallel-in-time-integration.html).
+entry at [parallelintime.org](/events/4th-pint-workshop/).

--- a/_posts/2014-12-08-workshop-in-2016-announcement.md
+++ b/_posts/2014-12-08-workshop-in-2016-announcement.md
@@ -15,5 +15,5 @@ The workshop series on parallel-in-time integration will continue in 2016 and ta
 continent for the first time.
 In November 2016, the workshop will be hosted by the [Banff International Research Station](http://www.birs.ca/) in
 Canada.
-Please check out the entry at [parallelintime.org](/events/upcoming/2016/5th-workshop-on-parallel-in-time-integration.html)
+Please check out the entry at [parallelintime.org](/events/5th-pint-workshop/)
 for more information.

--- a/_posts/2015-06-04-bylaws.md
+++ b/_posts/2015-06-04-bylaws.md
@@ -13,7 +13,7 @@ Bylaws for the parallel-in-time workshop series.
 With the aim to successfully continue the PinT workshop series even beyond the
 [5th workshop](/events/upcoming/2016/5th-workshop-on-parallel-in-time-integration.html) in Banff,
 Canada, a set of [bylaws](/events/bylaws.html) for the election of a scientific committee has been
-put in place during the workshop in [Dresden](/events/past/2015/4th-workshop-on-parallel-in-time-integration.html).
+put in place during the workshop in [Dresden](/events/4th-pint-workshop/).
 The bylaws define a set of rules for the election of a scientific committee.
 The committee is responsible for the coordination and promotion of the workshop series.
 We are looking forward to many more interesting PinT workshops!

--- a/_posts/2015-06-04-dresden-postnews.md
+++ b/_posts/2015-06-04-dresden-postnews.md
@@ -10,7 +10,7 @@ categories:
 Successful 4th Workshop on Parallel-in-Time Integration in Dresden, Germany.
 
 <!--more-->
-The [4th PinT workshop](/events/past/2015/4th-workshop-on-parallel-in-time-integration.html) in
+The [4th PinT workshop](/events/4th-pint-workshop/) in
 Dresden turned out to be another great event in the _Parallel-in-time integration_ workshop series:
 With 40 participants from 9 different countries, this workshop again provided a lively forum for
 many interesting discussions around a great many different aspects of PinT.
@@ -23,5 +23,5 @@ Moreover, in order to support the continuation of the workshop series,
 committee will take place within four weeks after the workshop.
 
 Certainly, everybody is now looking forward to the
-[5th workshop](/events/upcoming/2016/5th-workshop-on-parallel-in-time-integration.html) in the
+[5th workshop](/events/5th-pint-workshop/) in the
 series in November 2016 in Canada.

--- a/_posts/2015-11-13-toulouse-registration.md
+++ b/_posts/2015-11-13-toulouse-registration.md
@@ -9,5 +9,5 @@ categories:
 
 Submission is now open for the workshop on parallel-in-time integration in Toulouse in Franc, taking place on 11th-12th January 2016.
 Deadline for submissions is **December 10th 2015**.
-You can find more information here on [parallelintime.org](/events/upcoming/2016/cimi_semester.html) and on the
+You can find more information here on [parallelintime.org](/events/cimi_semester/) and on the
 [official website](http://inpact.inp-toulouse.fr/CIMI_Semester/wksp_parallel.html).

--- a/_posts/2015-4-20-toulouse-workshop-announcement.md
+++ b/_posts/2015-4-20-toulouse-workshop-announcement.md
@@ -10,5 +10,5 @@ categories:
 In addition to the [5th Workshop on Parallel-in-Time Integration](/events/upcoming/2016/5th-workshop-on-parallel-in-time-integration.html)
 in Banff, Canada in November 2016, another workshop also dedicated to the topic will take place in Toulouse in France
 from 11th-12th January 2016.
-You can find more information here on [parallelintime.org](/events/upcoming/2016/cimi_semester.html) and on the
+You can find more information here on [parallelintime.org](/events/cimi_semester/) and on the
 [official website](http://inpact.inp-toulouse.fr/CIMI_Semester/wksp_parallel.html).


### PR DESCRIPTION
Links to event websites in the news were no longer working, but should be correct again now.

Fixes #103 