### PR TITLE
removed double {{ }} in booktitle in multiple entries which, for …

### DIFF
--- a/_bibliography/pint.bib
+++ b/_bibliography/pint.bib
@@ -1595,7 +1595,7 @@
 	address = {Los Alamitos, CA, USA},
 	articleno = {92},
 	author = {Speck, Robert and Ruprecht, Daniel and Krause, Rolf and Emmett, Matthew and Minion, Michael L. and Winkel, Mathias and Gibbon, Paul},
-	booktitle = {{Proceedings of the International Conference on High Performance Computing, Networking, Storage and Analysis}},
+	booktitle = {Proceedings of the International Conference on High Performance Computing, Networking, Storage and Analysis},
 	location = {Salt Lake City, Utah},
 	numpages = {11},
 	pages = {92:1--92:11},
@@ -1766,10 +1766,10 @@
 
 @inproceedings{RuprechtEtAl2013_SC,
 	author = {Ruprecht, Daniel and Speck, Robert and Emmett, Matthew and Bolten, Matthias and Krause, Rolf},
-	booktitle = {{Proceedings of the 2013 Conference on High Performance Computing Networking, Storage and Analysis Companion}},
+	booktitle = {Proceedings of the 2013 Conference on High Performance Computing Networking, Storage and Analysis Companion},
 	location = {Denver, Colorado, USA},
 	series = {{SC '13 Companion}},
-	title = {{Poster: Extreme-scale space-time parallelism}},
+	title = {Poster: Extreme-scale space-time parallelism},
 	url = {http://sc13.supercomputing.org/sites/default/files/PostersArchive/tech_posters/post148s2-file3.pdf},
 	year = {2013}
 }
@@ -1904,7 +1904,7 @@
 		It is confirmed that the space-time-parallel method can provide speedup beyond the saturation of the spatial
 		parallelization.}},
 	author = {Croce, Roberto and Ruprecht, Daniel and Krause, Rolf},
-	booktitle = {{Modeling, Simulation and Optimization of Complex Processes -- {HPSC} 2012}},
+	booktitle = {Modeling, Simulation and Optimization of Complex Processes -- {HPSC} 2012},
 	editor = {Bock, Hans Georg and Hoang, Xuan Phu and Rannacher, Rolf and Schlöder, Johannes P.},
 	pages = {13--23},
 	publisher = {Springer International Publishing},
@@ -2088,7 +2088,7 @@
 		The capability of this approach to achieve speedups beyond the saturation of the pure space-parallel scheme is
 		demonstrated for the two-dimensional Burgers equation.}},
 	author = {Krause, Rolf and Ruprecht, Daniel},
-	booktitle = {{Domain Decomposition Methods in Science and Engineering {XXI}}},
+	booktitle = {Domain Decomposition Methods in Science and Engineering {XXI}},
 	editors = {Erhel, J. and Gander, M. J. and Halpern, L. and Pichot, G. and Sassi, T. and Widlund, O.},
 	pages = {647--655},
 	publisher = {Springer International Publishing},
@@ -2132,7 +2132,7 @@
 		Implications of using spatial coarsening strategies in PFASST's multi-level hierarchy in large-scale parallel
 		simulations are discussed.}},
 	author = {Speck, Robert and Ruprecht, Daniel and Emmett, Matthew and Bolten, Matthias and Krause, Rolf},
-	booktitle = {{Parallel Computing: Accelerating Computational Science and Engineering (CSE)}},
+	booktitle = {Parallel Computing: Accelerating Computational Science and Engineering ({CSE})},
 	editors = {Bader, M. and Bode, A. and Bungartz, H.-J. and Gerndt, M. and Joubert, G.R. and Peters, F.},
 	pages = {263--272},
 	publisher = {IOS Press},
@@ -2155,7 +2155,7 @@
 		It is demonstrated that SDC and PFASST can generate highly accurate solutions, and the performance in terms of
 		function evaluations required for a certain accuracy is analyzed and compared to a standard Runge-Kutta method.}},
 	author = {Speck, Robert and Ruprecht, Daniel and Krause, Rolf and Emmett, Matthew and Minion, Michael L. and Winkel, Mathias and Gibbon, Paul},
-	booktitle = {{Domain Decomposition Methods in Science and Engineering {XXI}}},
+	booktitle = {Domain Decomposition Methods in Science and Engineering {XXI}},
 	editors = {Erhel, J. and Gander, M. J. and Halpern, L. and Pichot, G. and Sassi, T. and Widlund, O.},
 	pages = {637--645},
 	publisher = {Springer International Publishing},
@@ -2576,7 +2576,7 @@
 		deteriorate as viscosity decreases and the flow becomes increasingly dominated by convection.
 		The effect is found to strongly depend on the spatial resolution.}},
 	author = {Steiner, J. and Ruprecht, Daniel and Speck, Robert and Krause, Rolf},
-	booktitle = {{Numerical Mathematics and Advanced Applications - ENUMATH 2013}},
+	booktitle = {Numerical Mathematics and Advanced Applications - {ENUMATH} 2013},
 	editor = {Abdulle, Assyr and Deparis, Simone and Kressner, Daniel and Nobile, Fabio and Picasso, Marco},
 	pages = {195--202},
 	publisher = {Springer International Publishing},


### PR DESCRIPTION
…some reason, leads some versions of biber to use all caps