### PR TITLE
Update pint.bib

### DIFF
--- a/_bibliography/pint.bib
+++ b/_bibliography/pint.bib
@@ -5184,15 +5184,6 @@ computing results, also for more realistic applications.},
 	year = {2021},
 }
 
-@unpublished{GoetschelEtAl2021,
-	abstract = {Getting good speedup -- let alone high parallel efficiency -- for parallel-in-time (PinT) integration examples can be frustratingly difficult. The high complexity and large number of parameters in PinT methods can easily (and unintentionally) lead to numerical experiments that overestimate the algorithm's performance. In the tradition of Bailey's article "Twelve ways to fool the masses when giving performance results on parallel computers", we discuss and demonstrate pitfalls to avoid when evaluating performance of PinT methods. Despite being written in a light-hearted tone, this paper is intended to raise awareness that there are many ways to unintentionally fool yourself and others and that by avoiding these fallacies more meaningful PinT performance results can be obtained.},
-	author = {Sebastian Goetschel and Michael Minion and Daniel Ruprecht and Robert Speck},
-	howpublished = {arXiv:2102.11670v1 [math.NA]},
-	title = {Twelve Ways To Fool The Masses When Giving Parallel-In-Time Results},
-	url = {http://arxiv.org/abs/2102.11670v1},
-	year = {2021},
-}
-
 @article{GrigoriEtAl2021,
 	author = {Laura Grigori and Sever A. Hirstoaga and Van-Thanh Nguyen and Julien Salomon},
 	doi = {10.1016/j.jcp.2021.110282},
@@ -5206,7 +5197,7 @@ computing results, also for more realistic applications.},
 	year = {2021},
 }
 
-@incollection{GötschelEtAl2021,
+@incollection{GoetschelEtAl2021,
 	author = {Sebastian Götschel and Michael Minion and Daniel Ruprecht and Robert Speck},
 	booktitle = {Springer Proceedings in Mathematics {\&} Statistics},
 	doi = {10.1007/978-3-030-75933-9_4},


### PR DESCRIPTION
Changed GötschelEtAl2021 to GoetschelEtAl2021 and removed the old GoetschelEtAl2021 entry which pointed to the arxiv preprint. Oh, the joy of Umlaute!