### PR TITLE
add next PinT workshop

### DIFF
--- a/_events_past/2024-13th-pint-workshop.md
+++ b/_events_past/2024-13th-pint-workshop.md
@@ -1,0 +1,34 @@
+---
+layout: page_event
+title: "PinT 2024: 13th Workshop on Parallel-in-Time Integration"
+date: 2023-11-02 12:00:00 +0000
+event_location: Bruges, Belgium
+event_start: 2024-02-05 00:00
+event_end: 2024-02-09 24:00
+event_url: https://time-x.eu/pint-2024/
+navbar: Events
+subnavbar: Upcoming
+organizers:
+  - name: Giovanni Samaey
+    homepage: https://www.kuleuven.be/wieiswie/en/person/00038151
+  - name: Stefan Vandewalle
+    homepage: https://www.kuleuven.be/wieiswie/en/person/00009501
+  - name: Ward Melis
+    homepage: https://www.kuleuven.be/wieiswie/en/person/00085858
+invited:
+  - name: Peter Düben (ECMWF)
+    homepage: https://www.ecmwf.int/en/about/who-we-are/staff-profiles/peter-dueben
+  - name: Stefanie Günther (LLNL)
+    homepage: https://www.researchgate.net/profile/Stefanie-Guenther-4
+  - name: Johan Meyers (KUL)
+    homepage: https://www.kuleuven.be/wieiswie/en/person/00011045
+  - name: Sebastian Schöps (TUD)
+    homepage: https://www.cem.tu-darmstadt.de/cem/group/schops.en.jsp
+permalink: /events/13th-pint-workshop/
+subtitle: "Brief overview"
+page_type: event_page
+no_lead: true
+---
+
+PinT 2024: the 13th Workshop on Parallel-in-time Integration will be hosted in Bruges, Belgium, by Prof. Giovanni Samaey, Prof. Stefan Vandewalle and Dr. Ward Melis.
+Please visit the conference website at  [https://time-x.eu/pint-2024/](https://time-x.eu/pint-2024/) for more information.

--- a/_events_upcoming/2025-14th-pint-workshop.md
+++ b/_events_upcoming/2025-14th-pint-workshop.md
@@ -1,7 +1,7 @@
 ---
 layout: page_event
 title: "PinT 2025: 14th Workshop on Parallel-in-Time Integration"
-date: 2025-07-07 12:00:00 +0000
+date: 2024-04-13 12:00:00 +0000
 event_location: Edinburgh, UK
 event_start: 2025-08-07 00:00
 event_end: 2027-08-11 24:00

--- a/_events_upcoming/2025-14th-pint-workshop.md
+++ b/_events_upcoming/2025-14th-pint-workshop.md
@@ -1,0 +1,28 @@
+---
+layout: page_event
+title: "PinT 2025: 14th Workshop on Parallel-in-Time Integration"
+date: 2025-07-07 12:00:00 +0000
+event_location: Edinburgh, UK
+event_start: 2025-08-07 00:00
+event_end: 2027-08-11 24:00
+event_url: 
+navbar: Events
+subnavbar: Upcoming
+organizers:
+  - name: Jemma Shipton
+    homepage: https://mathematics.exeter.ac.uk/people/profile/index.php?web_id=js1075
+  - name: David Acreman
+    homepage: 
+  - name: Beth Wingate
+    homepage: https://mathematics.exeter.ac.uk/people/profile/index.php?web_id=bw290
+  - name: Hiroe Yamazaki
+    homepage: https://www.imperial.ac.uk/people/h.yamazaki
+invited:
+
+permalink: /events/14th-pint-workshop/
+subtitle: "Brief overview"
+page_type: event_page
+no_lead: true
+---
+
+PinT 2025: the 14th Workshop on Parallel-in-time Integration will be hosted at the ICMS in Edinburgh, UK.


### PR DESCRIPTION
I have added some info about the next PinT workshop and moved the previous workshop to past events. Unfortunately I have not been able to view locally as I've had issues installing the correct version or Ruby - hope it's ok!